### PR TITLE
Revert "Added curl error handling"

### DIFF
--- a/redaxo_loader.php
+++ b/redaxo_loader.php
@@ -63,21 +63,10 @@ function curl_file_get_contents($url)
         curl_setopt($curly, CURLOPT_URL, $url);
         curl_setopt($curly, CURLOPT_USERAGENT, "REDAXO Loader");
         $content = curl_exec($curly);
-        
-        $error = curl_error($curly);
-        $errno = curl_errno($curly);
-        
-        if (CURLE_OK !== $errno || $error) {
-            if (!$error && function_exists('curl_strerror')) {
-                 $error = curl_strerror($errno);
-            }
-            throw new Exception('curl error '.$errno.' while downloading: '.$error);
-        }
-        
         curl_close($curly);
         return $content;
     }
-    throw new Exception('invalid url');
+    return false;
 }
 
 $releases = curl_file_get_contents('https://api.github.com/repos/' . REPO . '/releases');


### PR DESCRIPTION
Reverts FriendsOfREDAXO/redaxo_loader#8

Das war quasi doppelt gemoppelt. Die Funktion `curl_file_get_contents` gibt bereits ein false zurück, wenn der CURL-Aufruf schief geht, wenn die URL nicht erreichbar ist und gibt das dann in den Fehlermeldungen im HTML aus.

![Bildschirmfoto 2021-04-01 um 12 55 28](https://user-images.githubusercontent.com/16903055/113284881-941f1680-92ea-11eb-8705-ba1283d62bb8.png)
